### PR TITLE
Implement Flexible Filtering and Pagination for Articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "bootsnap", require: false
 # To generate data for seeding into database
 gem 'faker'
 
+# To add pagination
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# To generate data for seeding into database
+gem 'faker'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -358,6 +360,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  faker
   importmap-rails
   jbuilder
   pry-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.12.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -363,6 +375,7 @@ DEPENDENCIES
   faker
   importmap-rails
   jbuilder
+  kaminari
   pry-rails
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,5 @@
+class ArticlesController < ApplicationController
+  def index
+    @articles = Article.all
+  end
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -23,6 +23,8 @@ class ArticlesController < ApplicationController
 
       @articles = @articles.commented([params[:comments_count].to_i, 1].max) if params[:commented] == '1'
     end
+
+    @articles = @articles.page(params[:page])
   end
 
   private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,39 @@
 class ArticlesController < ApplicationController
+  before_action :set_variables, only: :index
+  before_action :sanatize_params, only: :index
+
   def index
     @articles = Article.all
+
+    @articles = @articles.search(params[:search]) if params[:search].present?
+    @articles = @articles.by_authors(params[:author_ids]) if params[:author_ids].present?
+
+    if params[:special] == 'hot'
+        days = [params[:days].to_i, 7].max
+        @articles = @articles.hot(days, params[:tag_ids])
+    elsif params[:special] == 'trending'
+      comments_count = [params[:comments_count].to_i, 5].max
+      days = [params[:days].to_i, 3].max
+      @articles = @articles.trending(comments_count, days, params[:tag_ids])
+    else
+      @articles = @articles.published if params[:published] == 'true'
+      @articles = @articles.un_published if params[:published] == 'false'
+      @articles = @articles.tagged(params[:tag_ids]) if params[:tagged] == '1'
+      @articles = @articles.recent([params[:days].to_i, 1].max) if params[:days].present?
+
+      @articles = @articles.commented([params[:comments_count].to_i, 1].max) if params[:commented] == '1'
+    end
+  end
+
+  private
+
+  def set_variables
+    @authors = Author.all
+    @tags = Tag.all
+  end
+
+  def sanatize_params
+    params[:tag_ids] = params[:tag_ids]&.reject(&:blank?).map(&:to_i) if params[:tag_ids].present?
+    params[:author_ids] = params[:author_ids]&.reject(&:blank?).map(&:to_i) if params[:author_ids].present?
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,7 @@
 class Article < ApplicationRecord
+
+  paginates_per 20
+
   belongs_to :author, class_name: 'Author'
   has_many :comments
   has_and_belongs_to_many :tags

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,22 +1,16 @@
-<div id="<%= dom_id article %>">
-  <p>
-    <strong>Title:</strong>
-    <%= article.title %>
-  </p>
-
-  <p>
-    <strong>Content:</strong>
-    <%= article.content %>
-  </p>
-
-  <p>
-    <strong>Published:</strong>
-    <%= article.published %>
-  </p>
-
-  <p>
-    <strong>Author:</strong>
-    <%= article.author.name %>
-  </p>
-
-</div>
+<tr id="<%= dom_id article %>">
+  <td><%= article.id %></td>
+  <td><%= article.author.name %></td>
+  <td><%= article.title %></td>
+  <td><%= article.content %></td>
+  <td><%= article.published ? 'Yes' : 'No' %></td>
+  <td><%= article.published_at %></td>
+  <td>
+    <% if article.respond_to?(:trending?) && article.trending? %>
+      <%= 'Trending' %>
+    <% elsif article.respond_to?(:hot?) && article.hot? %>
+      <%= 'Hot' %>
+    <% end %>
+  </td>
+  <td><%= article.comments.count %></td>
+</tr>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,0 +1,22 @@
+<div id="<%= dom_id article %>">
+  <p>
+    <strong>Title:</strong>
+    <%= article.title %>
+  </p>
+
+  <p>
+    <strong>Content:</strong>
+    <%= article.content %>
+  </p>
+
+  <p>
+    <strong>Published:</strong>
+    <%= article.published %>
+  </p>
+
+  <p>
+    <strong>Author:</strong>
+    <%= article.author.name %>
+  </p>
+
+</div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -96,4 +96,7 @@
       <% end %>
     </tbody>
   </table>
+  <div class="d-flex justify-content-center">
+    <%= paginate @articles %>
+  </div>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -4,8 +4,96 @@
 
 <h1>Articles</h1>
 
+<hr>
+<h2>Filter results</h2>
+<%= form_with method: :get do |form| %>
+  <div class="container">
+    <div class="row">
+      <div class="col-6 mb-2">
+        <div class="d-flex align-items-center">
+          <%= form.label :search, "Search:", class: 'mx-3' %>
+          <%= form.search_field :search, value: params[:search], class:'form-control', placeholder: 'Search by title or content...'%>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div class="d-flex align-items-center">
+          <%= form.label :days, "No. of days", class: 'mx-3' %>
+          <%= form.number_field :days, value: params[:days], class:'form-control w-75', placeholder: 'Filter articles published in past days'%>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div class="d-flex align-items-center justify-content-between">
+          <%= form.label :published, "Publish status", class: 'mx-3' %>
+          <%= form.select :published, [['All', 'all'], ['Published', 'true'], ['Unpublished', 'false']], { selected: params[:published] }, class:'form-control w-75'%>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div class="d-flex align-items-center justify-content-between">
+          <%= form.label :author_ids, 'Author', class: 'mx-3' %>
+          <%= form.collection_select :author_ids, @authors, :id, :name, { selected: params[:author_ids]&.reject(&:blank?) }, { multiple: true, class: 'form-control'} %>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div>
+          <%= form.label :tagged, 'Tagged articles', class: 'mx-3' %>
+          <%= form.check_box :tagged, { checked: params[:tagged] == '1' } %>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div class="d-flex align-items-center justify-content-between">
+          <%= form.label :tag_ids, 'Tags', class: 'mx-3' %>
+          <%= form.collection_select :tag_ids, @tags, :id, :name, { selected: params[:tag_ids]&.reject(&:blank?) }, { multiple: true, class: 'form-control'} %>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div>
+          <%= form.label :comments, 'Commented articles', class: 'mx-3' %>
+          <%= form.check_box :comments , { checked: params[:comments] == '1' } %>
+        </div>
+      </div>
+      <div class="col-6 mb-2">
+        <div class="d-flex align-items-center justify-content-between">
+          <%= form.label :comments_count, 'Minimum comments count', class: 'mx-3' %>
+          <%= form.number_field :comments_count, value: params[:comments_count], class: 'form-control', placeholder: 'Enter comments count' %>
+        </div>
+      </div>
+      <hr>
+      <div class="col-12 mb-2">
+        <div class="d-flex align-items-center justify-content-between">
+          <%= form.label :special, "Special filter", class: 'mx-3' %>
+          <%= form.select :special, [['Select', ''], ['Hot', 'hot'], ['Trending', 'trending']], { selected: params[:special] }, class:'form-control w-75'%>
+          <div class="w-600 mx-3">These filters may effect other filters</div>
+        </div>
+      </div>
+      <hr>
+      <div class="text-end">
+        <%= form.submit "Search", class: 'btn btn-primary' %>
+      </div>
+    </div>
+  </div>
+<% end %>
+<hr>
+
 <div id="articles">
-  <% @articles.each do |article| %>
-    <%= render article %>
-  <% end %>
+  <div>No. of records found: <%= @articles.length %></div>
+  <hr>
+  <table>
+    <thead>
+      <tr class='overflow-scroll'>
+        <th>ID</th>
+        <th>AUTHOR_NAME</th>
+        <th>TITLE</th>
+        <th>CONTENT</th>
+        <th>PUBLISHED</th>
+        <th>PUBLISHED AT</th>
+        <th>FEATURE ARTICLE</th>
+        <th>Comments #</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @articles.each do |article| %>
+        <%= render article %>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,11 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Articles" %>
+
+<h1>Articles</h1>
+
+<div id="articles">
+  <% @articles.each do |article| %>
+    <%= render article %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,11 +13,13 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
     <%= yield %>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resources :articles
+  root 'articles#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :articles
+  resources :articles do
+    get '/articles/:page', action: :index, on: :collection
+  end
   root 'articles#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,61 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# db/seeds.rb
+
+require 'faker'
+
+Comment.delete_all
+Article.delete_all
+Tag.delete_all
+User.delete_all
+
+users = 25.times.map do
+  User.create!(
+    name: Faker::Name.name,
+    email: Faker::Internet.unique.email,
+    password: 'password',
+    type: nil
+  )
+end
+
+authors = 25.times.map do
+  User.create!(
+    name: Faker::Name.name,
+    email: Faker::Internet.unique.email,
+    password: 'password',
+    type: 'Author'
+  )
+end
+
+tags = 20.times.map do
+  Tag.create!(
+    name: Faker::Lorem.unique.word,
+    description: Faker::Lorem.sentence
+  )
+end
+
+articles = 200.times.map do
+  published  = [true, false].sample
+
+  Article.create!(
+    title: Faker::Book.title,
+    content: Faker::Lorem.paragraphs(number: 5).join("\n"),
+    published: published,
+    author_id: authors.sample.id,
+    published_at: published ? Time.at(rand(30.days.ago.to_f..2.hours.ago.to_f)) : nil
+  )
+end
+
+articles.each do |article|
+  article.tags << tags.sample(rand(1..4))
+end
+
+comments = 500.times.map do
+  Comment.create!(
+    content: Faker::Lorem.sentence,
+    user_id: users.sample.id,
+    article_id: articles.sample.id
+  )
+end

--- a/spec/controllers/article_controller_spec.rb
+++ b/spec/controllers/article_controller_spec.rb
@@ -1,0 +1,397 @@
+require 'rails_helper'
+
+RSpec.describe ArticlesController, type: :controller do
+  describe '#index' do
+    let!(:un_published_article) do
+      create(
+        :article,
+        published: false,
+        author: author1,
+        tag_ids: [ tag1.id ],
+        title:'non published title',
+        content: 'non published content by author1, having tag1'
+      )
+    end
+    let!(:published_article_1) do
+      create(
+        :article,
+        published: true,
+        published_at: 7.days.ago - 1.minutes,
+        author: author1,
+        title:'non recent published title',
+        content: 'non recent published content by author1, having no tag'
+      )
+    end
+    let!(:published_article_2) do
+      create(
+        :article,
+        published: true,
+        published_at: 7.days.ago - 2.minutes,
+        author: author2,
+        tag_ids: [ tag2.id ],
+        title:'non recent published title',
+        content: 'non recent published content by author2, having tag2'
+      )
+    end
+    let!(:recent_article_1) do
+      create(
+        :article,
+        :commented,
+        comments_count: 1,
+        published: true,
+        published_at: 7.days.ago + 1.minute,
+        author: author1,
+        tag_ids: [ tag1.id, tag2.id ],
+        title:'recently published title',
+        content: 'recently published content by author1, having tag1 and tag2, and 1 comment'
+      )
+    end
+    let!(:recent_article_2) do
+      create(
+        :article,
+        published: true,
+        published_at: 4.days.ago + 1.minute,
+        tag_ids: [ tag1.id ],
+        author: author2, title:'recently published title',
+        content: 'recently published content by author2, having tag1'
+      )
+    end
+    let!(:trending_article_1) do
+      create(
+        :article,
+        :commented,
+        comments_count: 5,
+        published: true,
+        published_at: 3.days.ago + 1.minute,
+        author: author1,
+        tag_ids: [ tag1.id ],
+        title:'recently published title',
+        content: 'recently published content by author1, having tag1, and 5 comments'
+      )
+    end
+    let!(:trending_article_2) do
+      create(
+        :article,
+        :commented,
+        comments_count: 6,
+        published: true,
+        published_at: 2.days.ago + 1.minute,
+        author: author1,
+        tag_ids: [ tag1.id, tag2.id ],
+        title:'recently published title',
+        content: 'recently published content by author1, having tag1 and tag2, and 6 comments'
+      )
+    end
+    let!(:trending_article_3) do
+      create(
+        :article,
+        :commented,
+        comments_count: 7,
+        published: true,
+        published_at: 2.days.ago + 1.minute,
+        author: author2,
+        tag_ids: [ tag2.id ],
+        title:'recently published title',
+        content: 'recently published content by author2, having tag2, and 7 comments'
+      )
+    end
+
+    let!(:author1) { create(:author) }
+    let!(:author2) { create(:author) }
+    let!(:tag1) { create(:tag) }
+    let!(:tag2) { create(:tag) }
+
+    it 'returns all articles' do
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:articles)).to eq [
+        un_published_article,
+        published_article_1,
+        published_article_2,
+        recent_article_1,
+        recent_article_2,
+        trending_article_1,
+        trending_article_2,
+        trending_article_3
+      ]
+    end
+
+    context 'when filter by search' do
+      it 'returns articles with matching text in title or content' do
+        get :index, params: { search: 'recently' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          recent_article_1,
+          recent_article_2,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter by authors' do
+      it 'returns articles by selected authors' do
+        get :index, params: { author_ids: [ author1.id ] }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          un_published_article,
+          published_article_1,
+          recent_article_1,
+          trending_article_1,
+          trending_article_2
+        ]
+      end
+    end
+
+    context 'when filter published articles' do
+      it 'returns published articles' do
+        get :index, params: { published: 'true' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          published_article_1,
+          published_article_2,
+          recent_article_1,
+          recent_article_2,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter un published articles' do
+      it 'returns un published articles' do
+        get :index, params: { published: 'false' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [ un_published_article ]
+      end
+    end
+
+    context 'when filter tagged articles' do
+      it 'returns tagged articles' do
+        get :index, params: { tagged: '1' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          un_published_article,
+          published_article_2,
+          recent_article_1,
+          recent_article_2,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter tagged articles with specific tags' do
+      it 'returns tagged articles with specific tags' do
+        get :index, params: { tagged: '1', tag_ids: [ tag1.id ] }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          un_published_article,
+          recent_article_1,
+          recent_article_2,
+          trending_article_1,
+          trending_article_2
+        ]
+      end
+    end
+
+    context 'when filter with specific tags without selecing tagged' do
+      it 'returns all articles' do
+        get :index, params: { tag_ids: [ tag1.id ] }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          un_published_article,
+          published_article_1,
+          published_article_2,
+          recent_article_1,
+          recent_article_2,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter by days' do
+      it 'returns published articles published with in last number of days' do
+        get :index, params: { days: 4 }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          recent_article_2,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter commented articles' do
+      it 'returns commented articles' do
+        get :index, params: { commented: '1' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          recent_article_1,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter commented articles with specific comments count' do
+      it 'returns commented articles with atleast number of specified comments' do
+        get :index, params: { commented: '1', comments_count: 6 }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter with specific comments counts without selecing commented' do
+      it 'returns all articles' do
+        get :index, params: { comments_count: 6 }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          un_published_article,
+          published_article_1,
+          published_article_2,
+          recent_article_1,
+          recent_article_2,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter by hot articles' do
+      it 'returns recently published articles with comments' do
+        get :index, params: { special: 'hot' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          recent_article_1,
+          trending_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter by hot articles with search' do
+      it 'returns recently published articles with comments and search text in title or content' do
+        get :index, params: { special: 'hot', search: 'tag2' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          recent_article_1,
+          trending_article_2,
+          trending_article_3
+        ]
+      end
+    end
+
+    context 'when filter by hot articles with specific authors' do
+      it 'returns recently published articles by specific authors with comments' do
+        get :index, params: { special: 'hot', author_ids: [ author2.id ] }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [ trending_article_3 ]
+      end
+    end
+
+    context 'when filter by trending articles' do
+      it 'returns trending articles' do
+        get :index, params: { special: 'trending' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          trending_article_3,
+          trending_article_2,
+          trending_article_1
+        ]
+      end
+    end
+
+    context 'when filter by trending articles with search' do
+      it 'returns trending articles with search text in title or content' do
+        get :index, params: { special: 'trending', search: 'tag2' }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [
+          trending_article_3,
+          trending_article_2
+        ]
+      end
+    end
+
+    context 'when filter by trending articles with specific authors' do
+      it 'returns trending articles by specific authors' do
+        get :index, params: { special: 'trending', author_ids: [ author2.id ] }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:articles)).to eq [ trending_article_3 ]
+      end
+    end
+
+    describe 'pagination' do
+      before do
+        allow(Article).to receive(:default_per_page).and_return(4)
+      end
+
+      context 'when filter by page 1' do
+        it 'returns first 4 articles' do
+          get :index, params: { page: 1 }
+
+          expect(response).to have_http_status(:ok)
+          expect(assigns(:articles)).to eq [
+            un_published_article,
+            published_article_1,
+            published_article_2,
+            recent_article_1,
+          ]
+        end
+      end
+
+      context 'when filter by page 2' do
+        it 'returns the second 4 articles' do
+          get :index, params: { page: 2 }
+
+          expect(response).to have_http_status(:ok)
+          expect(assigns(:articles)).to eq [
+            recent_article_2,
+            trending_article_1,
+            trending_article_2,
+            trending_article_3
+          ]
+        end
+      end
+
+      context 'when filter by search and page 2' do
+        it 'returns the page 2 articles with matching title or content' do
+          get :index, params: { search: 'recently', page: 2 }
+
+          expect(response).to have_http_status(:ok)
+          expect(assigns(:articles)).to eq [ trending_article_3 ]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**PR Description**
This PR add the `ArticlesController#index` action to view and support a wide range of dynamic filters and pagination. It enables flexible querying of articles based on author, tags, publication status, recentness, and comment activity, with special logic for "hot" and "trending" articles.

**Summary**
- Implemented advanced filtering in `index`:
  - `search` by text
  - `author_ids` filter
  - `tag_ids` filter
  - `published` / `un_published` status
  - `recent` articles based on days
  - `commented` articles based on minimum comments
- Added support for:
  - `special=hot` → filters articles based on days + tag_ids
  - `special=trending` → filters articles based on comments_count, days, and tag_ids
- Pagination integrated via **kaminari** gem (`.page(params[:page])`)
- Added `set_variables` to preload authors and tags
- Added `sanatize_params` to clean up `tag_ids` and `author_ids` from blank values

**Before Testing**
Run the following command in terminal to seed the data into database.
- `rails db:seed`
I am using **faker** gem to generate random data.

**How to Test**
1. Start the app and try filter with various query parameters such as:
   - `?search=ruby`
   - `?author_ids[]=1&author_ids[]=2`
   - `?tag_ids[]=3&tag_ids[]=4`
   - `?published=true`
   - `?commented=1&comments_count=5`
   - `?special=hot&days=7&tag_ids[]=1`
   - `?special=trending&comments_count=6&days=3`
   - `?page=2`